### PR TITLE
first pass at benchmark suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 About Trivial-Benchmark
 -----------------------
-Frequently I want to do a quick benchmark comparison of my functions. `TIME` is nice to get some data, but it's limited to a single run so there isn't really much of a statistical value in it. Trivial-benchmark runs a block of code many times and outputs some statistical data for it. On SBCL this includes the data from `TIME`, for all other implementations just the REAL- and RUN-TIME data. However, you can extend the system by adding your own `metric`s to it, or even by adding additional statistical `compute`ations. 
 
-How To
-------
+Frequently I want to do a quick benchmark comparison of my functions. `TIME` is nice to get some data, but it's limited to a single run so there isn't really much of a statistical value in it. Trivial-Benchmark runs a block of code many times and outputs some statistical data for it. On SBCL this includes the data from `TIME`, for all other implementations just the REAL- and RUN-TIME data. However, you can extend the system by adding your own `metric`s to it, or even by adding additional statistical `compute`ations. 
+
+Measurement How-To
+------------------
+
 For basic throwaway benchmarking, the `with-timing` macro should suffice:
 
     (benchmark:with-timing (1000)
@@ -42,3 +44,100 @@ You can also implement a new computation type that is used to display the differ
     (defmethod compute ((x (eql :maximum)) (metric metric))
       (reduce-samples metric #'max))
 
+Benchmark Suites
+----------------
+
+Analogous to unit testing, *performance testing* or *benchmark testing* is a useful way to measure performance regressions in a code base. Trivial-Benchmark has **preliminary support** for defining and running benchmarks.
+
+First, a *benchmark package* needs to be defined, which is essentially a normal Common Lisp package with some additional bookkeeping.
+
+    (define-benchmark-package #:my-app-benchmarks
+      (:use #:my-app)
+      (:export #:run-benchmarks))
+
+The macro `define-benchmark-package` automatically uses the `COMMON-LISP` and the `TRIVIAL-BENCHMARK` packages.
+
+After the package has been defined, you can define benchmarks like normal Lisp function definitions using the `define-benchmark` macro. Within the `define-benchmark` macro, you use `with-benchmark-sampling` around forms that you wish to measure.
+
+    (define-benchmark measure-trig ()
+      (declare (optimize speed))
+      (loop :repeat 100000
+            :for r := (random 1.0d0)
+            :do (with-benchmark-sampling
+                  (+ (sin r)
+                     (cos r)
+                     (tan r)))))
+
+The macro `with-benchmark-sampling` can be called many times throughout the body of the `define-benchmark`, and even called within functions called within the body. In other words, you're able to write something like this:
+
+    (defun trig-trial (r)
+      (with-benchmark-sampling
+        (+ (sin r) (cos r) (tan r))))
+
+    (defun inv-trig-trial (r)
+      (with-benchmark-sampling
+        (+ (asin r) (acos r) (atan r))))
+    
+    (define-benchmark measure-all-trig ()
+      (declare (optimize speed))
+      (loop :repeat 100000
+            :for r := (random 1.0d0)
+            :do (trig-trial r)
+                (inv-trig-trial r)))
+
+You can run the benchmarks of a package by doing:
+
+    (run-package-benchmarks :package ':my-app-benchmarks
+                            :verbose t)
+
+You can elide the `:package` argument if you're in the package already. Running this will give:
+
+    > (run-package-benchmarks :package ':my-app-benchmarks 
+                              :verbose t)
+    Benchmarking MEASURE-ALL-TRIG...done.
+    Benchmarking BENCH-TRIG...done.
+    #<HASH-TABLE :TEST EQ :COUNT 2 {1002FD8243}>
+
+The returned hash table contains a summary of all of the statistics, which you can further process as needed (e.g., record, plot, etc.). The table maps the benchmark names to an alist of metrics and their computed statistics. We can inspect this easily enough:
+
+```
+> (alexandria:hash-table-alist *)
+((BENCH-TRIG
+  (REAL-TIME :SAMPLES 100000 :TOTAL 52/125 :MINIMUM 0 :MAXIMUM 3/1000 :MEDIAN 0
+   :AVERAGE 13/3125000 :DEVIATION 6.482819e-5)
+  (RUN-TIME :SAMPLES 100000 :TOTAL 383/1000 :MINIMUM 0 :MAXIMUM 1/1000 :MEDIAN
+   0 :AVERAGE 383/100000000 :DEVIATION 6.176837e-5)
+  (USER-RUN-TIME :SAMPLES 100000 :TOTAL 52663/250000 :MINIMUM 1/1000000
+   :MAXIMUM 53/1000000 :MEDIAN 1/500000 :AVERAGE 52663/25000000000 :DEVIATION
+   9.770944e-7)
+  (SYSTEM-RUN-TIME :SAMPLES 100000 :TOTAL 94299/500000 :MINIMUM 1/1000000
+   :MAXIMUM 87/1000000 :MEDIAN 1/500000 :AVERAGE 94299/50000000000 :DEVIATION
+   1.1286627e-6)
+  (PAGE-FAULTS :SAMPLES 100000 :TOTAL 0 :MINIMUM 0 :MAXIMUM 0 :MEDIAN 0
+   :AVERAGE 0 :DEVIATION 0.0)
+  (GC-RUN-TIME :SAMPLES 100000 :TOTAL 0 :MINIMUM 0 :MAXIMUM 0 :MEDIAN 0
+   :AVERAGE 0 :DEVIATION 0.0)
+  (BYTES-CONSED :SAMPLES 100000 :TOTAL 0 :MINIMUM 0 :MAXIMUM 0 :MEDIAN 0
+   :AVERAGE 0 :DEVIATION 0.0)
+  (EVAL-CALLS :SAMPLES 100000 :TOTAL 0 :MINIMUM 0 :MAXIMUM 0 :MEDIAN 0 :AVERAGE
+   0 :DEVIATION 0.0))
+ (MEASURE-ALL-TRIG
+  (REAL-TIME :SAMPLES 200000 :TOTAL 102/125 :MINIMUM 0 :MAXIMUM 1/200 :MEDIAN 0
+   :AVERAGE 51/12500000 :DEVIATION 6.4601496e-5)
+  (RUN-TIME :SAMPLES 200000 :TOTAL 77/100 :MINIMUM 0 :MAXIMUM 1/1000 :MEDIAN 0
+   :AVERAGE 77/20000000 :DEVIATION 6.192881e-5)
+  (USER-RUN-TIME :SAMPLES 200000 :TOTAL 41371/100000 :MINIMUM 1/1000000
+   :MAXIMUM 1/12500 :MEDIAN 1/500000 :AVERAGE 41371/20000000000 :DEVIATION
+   1.2130914e-6)
+  (SYSTEM-RUN-TIME :SAMPLES 200000 :TOTAL 363543/1000000 :MINIMUM 1/1000000
+   :MAXIMUM 11/100000 :MEDIAN 1/500000 :AVERAGE 363543/200000000000 :DEVIATION
+   1.4713012e-6)
+  (PAGE-FAULTS :SAMPLES 200000 :TOTAL 0 :MINIMUM 0 :MAXIMUM 0 :MEDIAN 0
+   :AVERAGE 0 :DEVIATION 0.0)
+  (GC-RUN-TIME :SAMPLES 200000 :TOTAL 0 :MINIMUM 0 :MAXIMUM 0 :MEDIAN 0
+   :AVERAGE 0 :DEVIATION 0.0)
+  (BYTES-CONSED :SAMPLES 200000 :TOTAL 15106048 :MINIMUM 0 :MAXIMUM 131072
+   :MEDIAN 0 :AVERAGE 236032/3125 :DEVIATION 1595.1276)
+  (EVAL-CALLS :SAMPLES 200000 :TOTAL 0 :MINIMUM 0 :MAXIMUM 0 :MEDIAN 0 :AVERAGE
+   0 :DEVIATION 0.0)))
+```

--- a/package.lisp
+++ b/package.lisp
@@ -55,5 +55,12 @@
   (:export
    #:type=
    #:print-table
-   #:round-to))
+   #:round-to)
+  ;; suite.lisp
+  (:export
+   #:find-benchmark-package
+   #:define-benchmark-package
+   #:define-benchmark
+   #:with-benchmark-sampling
+   #:run-package-benchmarks))
 

--- a/suite.lisp
+++ b/suite.lisp
@@ -1,0 +1,89 @@
+#|
+ This file is a part of Trivial-Benchmark
+ (c) 2016 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Robert Smith <quad@symbo1ics.com>
+|#
+
+(in-package #:org.shirakumo.trivial-benchmark)
+
+(defvar *benchmark-packages* (make-hash-table :test 'eq)
+  "A table mapping package objects (which are benchmark packages) to a list of fbound symbols.")
+
+(defun find-benchmark-package (package-designator)
+  "Find the benchmark package designated by PACKAGE-DESIGNATOR and return it, otherwise return NIL if it doesn't exist."
+  (let ((package-object (find-package package-designator)))
+    (if (or (null package-object)
+            (not (nth-value 1 (gethash package-object *benchmark-packages*))))
+        nil
+        package-object)))
+
+(defmacro define-benchmark-package (name &body package-options)
+  "Define a package as if by DEFPACKAGE, except that both the COMMON-LISP and TRIVIAL-BENCHMARK packages are used, and that this package is designated as one containing benchmarks."
+  `(progn
+     (defpackage ,name
+       (:use #:trivial-benchmark #:cl)
+       ,@package-options)
+     (setf (gethash (find-package ',name) *benchmark-packages*) nil)
+     (find-package ',name)))
+
+(defvar *current-suite-report*)         ; Table mapping fn name -> metric alist
+(defvar *current-benchmark*)            ; Name of current benchmark
+(defvar *current-timer*)                ; Timer used in the current benchmark.
+
+(defmacro with-benchmark-sampling (&body forms)
+  "Benchmark the execution of the forms FORMS within the context of a DEFINE-BENCH macro. Acts like PROGN."
+  `(with-sampling (*current-timer*)
+     ,@forms))
+
+(defun metrics-alist (timer &optional (computations *default-computations*))
+  (loop :for metric :in (metrics timer)
+        :collect (cons (type-of metric)
+                       (mapcan #'list
+                               computations
+                               (compute computations metric)))))
+
+(defmacro define-benchmark (name args &body body)
+  "Define a benchmark named NAME. The structure of this macro is that of DEFUN, except that WITH-BENCHMARK-SAMPLING can be called to collect metrics on the enclosed forms.
+
+ARGS must be a lambda list that does not require arguments present at the call site."
+  (check-type name symbol)
+  (let ((benchmark-name name))
+    (multiple-value-bind (forms decls doc)
+        (alexandria:parse-body body :documentation t)
+      `(progn
+         (defun ,benchmark-name ,args
+           ,@(alexandria:ensure-list doc)
+           ,@decls
+           (let ((*current-timer*     (benchmark:make-timer))
+                 (*current-benchmark* ',benchmark-name))
+             (unwind-protect (progn ,@forms)
+               (when (boundp '*current-suite-report*)
+                 (setf (gethash ',benchmark-name *current-suite-report*)
+                       (metrics-alist *current-timer*))))))
+         (pushnew ',benchmark-name
+                  (gethash (find-benchmark-package
+                            (symbol-package ',benchmark-name))
+                           *benchmark-packages*))
+         ',benchmark-name))))
+
+(defun run-package-benchmarks (&key (package *package*)
+                                    (verbose nil))
+  "Run all of the benchmarks associated with the benchmark package PACKAGE, the current one by default.
+
+Return a hash table mapping benchmark names to their metrics represented as lists. In particular, it will be an alist whose CARs are metrics and whose CDRs are plists of computations.
+
+VERBOSE is a generalized boolean that controls output verbosity while testing.
+"
+  (let ((benchmark-package (find-benchmark-package package)))
+    (when (null benchmark-package)
+      (error "The benchmark package ~A isn't defined." package))
+    (let ((*current-suite-report* (make-hash-table :test 'eq)))
+      ;; Collect the report.
+      (loop :for fn :in (gethash benchmark-package *benchmark-packages*)
+            :do (when verbose
+                  (format *trace-output* "~&Benchmarking ~S..." fn))
+                (funcall fn)
+                (when verbose
+                  (format *trace-output* "done.~%")))
+      ;; Return the results collected.
+      *current-suite-report*)))

--- a/trivial-benchmark.asd
+++ b/trivial-benchmark.asd
@@ -15,8 +15,10 @@
   :author "Nicolas Hafner <shinmera@tymoon.eu>"
   :maintainer "Nicolas Hafner <shinmera@tymoon.eu>"
   :description "An easy to use benchmarking system."
+  :depends-on (#:alexandria)
   :serial T
   :components ((:file "package")
                (:file "toolkit")
                (:file "timer")
-               (:file "samples")))
+               (:file "samples")
+               (:file "suite")))


### PR DESCRIPTION
This is a first pass at what the suites might look like (Issue #2). I didn't want to introduce too much baggage (like first class notions of "suites" and etc.).

Still some things that are undecided:
- Adding a good way to print results nicely.
- Whether the data structure that summarizes the results (table[function names] -> alist[metrics] -> plists[computations] -> numeric values) is sufficient. I chose not to save the timer object in case tons of samples got saved.
- Whether any reasonable additional bookkeeping functionality needs to be implemented.
- A careful look at whether any `EVAL-WHEN`s would be reasonable. I don't think they're needed.

@Shinmera, Looking for review, then I can do any modifications and cleanup, removing the [DO NOT MERGE] when ready.
