### PR TITLE
Add WITH-SUITE-REPORT

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -62,5 +62,6 @@
    #:define-benchmark-package
    #:define-benchmark
    #:with-benchmark-sampling
-   #:run-package-benchmarks))
+   #:run-package-benchmarks
+   #:with-suite-report))
 


### PR DESCRIPTION
This allows one to capture a report even when running a package
benchmark individually (i.e. *not* via RUN-PACKAGE-BENCHMARKS).

For example, in

```
(define-package-benchmark #:my-benchmarks
  ;; ...
  )

(in-package #:my-benchmarks)

(define-benchmark my-neat-benchmark ()
  ;; ...
  )

(define-benchmark my-very-slow-slow-slow-benchmark ()
  ;; ...
  )
```

you could of course run the full package benchmarks, but you may only
be interested for the moment in MY-NEAT-BENCHMARK. Prior to this
change, running `(my-neat-benchmark)` would execute the benchmark yet
return no useful sample information. With this change, we can capture
a report for individual (and any collection of individual benchmarks)
outside of RUN-PACKAGE-BENCHMARKS

```
(with-suite-report (report)
  (my-neat-benchmark)
  (report report)
  ;; do other stuff with report
)
```

Of course this could be achieved by manually
binding *current-suite-report*, etc., but I think the above is more
easily remembered on-the-fly.