### PR TITLE
Maybe floatify printed metrics

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -29,6 +29,7 @@
   (:export
    #:*default-metrics*
    #:*default-computations*
+   #:*print-rationals*
    #:metric
    #:running
    #:start

--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -6,13 +6,25 @@
 
 (in-package #:org.shirakumo.trivial-benchmark)
 
+(defvar *print-rationals* t
+  "Print metrics as rationals where appropriate if T. Otherwise, print as floats.")
+
+(defun floatify (val)
+  (if (and val
+           (not *print-rationals*)
+           (not (integerp val))
+           (rationalp val))
+      (float val)
+      val))
+
 (defun print-table (table &key (stream T) (padding 2))
   "Prints a table (each list in TABLE being a row) with proper spacing."
   (let ((widths (apply #'map 'list #'max (loop for row in table
                                                collect (loop for field in row
                                                              collect (+ padding (length (princ-to-string field))))))))
     (dolist (row table)
-      (apply #'format stream (format NIL "~~&~{~~~da~}~~%" widths) row))))
+      (apply #'format stream (format NIL "~~&~{~~~da~}~~%" widths)
+             (mapcar #'floatify row)))))
 
 (defun round-to (num n)
   "Rounds NUM to N digits after the dot."


### PR DESCRIPTION
Rationals are, IMO, sometimes hard to interpret. This PR introduces a
variable `*print-rationals*`, which when `T` does nothing special --
metrics are printed as they always have been; when `nil`,
`print-table` will convert metrics of type `(and rational (not
integer))` to `float`s, which I believe are much easier to read
at-a-glance: e.g. `48959/62500` vs `0.783344`.

This does not affect the underlying data (e.g. metrics in a `timer`
object) -- only the printed representation (via `report` or
`print-table`).