### PR TITLE
Allow to pass :samplers as a variable.

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -249,6 +249,9 @@ See COMMIT-SAMPLES-FORM")
 Creates a timer instance according to TIMER, runs WITH-SAMPLING N
 times, and then REPORTs the timer using the additional REPORT-ARGS.
 
+SAMPLERS argument is evaluated during compile time and can be a list
+or a name of a global variable holding a list of symbols.
+
 See TIMER (type)
 See WITH-SAMPLING
 See REPORT"))

--- a/timer.lisp
+++ b/timer.lisp
@@ -156,6 +156,11 @@
                        &body forms)
   (remf report-args :samplers)
   (remf report-args :timer)
+
+  (when (symbolp samplers)
+    (setf samplers
+          (eval samplers)))
+  
   (let ((timer (gensym "TIMER")))
     `(let ((,timer ,timer-form))
        (loop repeat ,n


### PR DESCRIPTION
This fix allows you to define a new set of samplers like this:

```lisp
(eval-always
  (defparameter *samplers*
    (list* 'messages-per-second
           *default-samplers*)))
```

and then to pass `*samplers*` as :`samplers` argument to the `WITH-TIMING` macro:

```lisp
(with-timing (num-iterations
              :samplers *samplers*)
  ...)
```

Without this fix, `WITH-TIMING` macro was expanded to:

```lisp
(with-sampling (#:timer604
                . *samplers*)
  ...)
```

and failed.

Without this fix it is impossible to reuse `*default-samplers*` and add custom samplers to this list if you don't want to push these custom samplers to the `*default-samplers*`.